### PR TITLE
Fixed up for latest gmail interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# gmail-fixed-font
+
+A Greasemonkey script that applies the browser's monospace font to message body text and compose window in Gmail.
+
+## Installation
+### Chrome
+1. Download gmail-fixed-font.user.js
+2. Visit chrome://extensions/ and drag the downloaded gmail-fixed-font.user.js onto the window.
+
+### Firefox
+1. Install [Greasemonkey](https://addons.mozilla.org/firefox/addon/748)
+2. [Click to install](https://github.com/dooferlad/gmail-fixed-font/raw/master/gmail-fixed-font.user.js)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Greasemonkey script that applies the browser's monospace font to message body 
 
 ## Installation
 ### Chrome
-1. Download gmail-fixed-font.user.js
+1. Download [gmail-fixed-font.user.js](https://github.com/dooferlad/gmail-fixed-font/raw/master/gmail-fixed-font.user.js)
 2. Visit chrome://extensions/ and drag the downloaded gmail-fixed-font.user.js onto the window.
 
 ### Firefox

--- a/gmail-fixed-font.user.js
+++ b/gmail-fixed-font.user.js
@@ -13,7 +13,9 @@
 // Plain-text Message Body
 var css = ".ii, .Ak { font: .9em monospace !important; }";
 // Quoted Text
-css += ".im, .gmail_quote { color: #666 !important; }";
+css += ".im, .gmail_quote { !important; }";
+// Compose Interface
+css += ".editable { font: .8em monospace !important; }";
 
 if (typeof GM_addStyle != "undefined") {
     GM_addStyle(css);

--- a/gmail-fixed-font.user.js
+++ b/gmail-fixed-font.user.js
@@ -13,8 +13,6 @@
 
 // Plain-text Message Body
 var css = ".ii, .Ak { font: medium monospace !important; }";
-// Quoted Text
-css += ".im, .gmail_quote { !important; }";
 // Compose Interface
 css += ".editable { font: medium monospace !important; }";
 

--- a/gmail-fixed-font.user.js
+++ b/gmail-fixed-font.user.js
@@ -2,20 +2,21 @@
 // @name           Gmail Fixed Font
 // @namespace      http://www.indelible.org/
 // @description    Fixed-font message bodies for Gmail
-// @author         Jon Parise
-// @version        1.23
+// @author         Jon Parise, James Tunnicliffe
+// @version        1.24
 // @include        http://mail.google.com/*
 // @include        https://mail.google.com/*
 // @include        http://*.mail.google.com/*
 // @include        https://*.mail.google.com/*
+// @grant          GM_addStyle
 // ==/UserScript==
 
 // Plain-text Message Body
-var css = ".ii, .Ak { font: .9em monospace !important; }";
+var css = ".ii, .Ak { font: medium monospace !important; }";
 // Quoted Text
 css += ".im, .gmail_quote { !important; }";
 // Compose Interface
-css += ".editable { font: .8em monospace !important; }";
+css += ".editable { font: medium monospace !important; }";
 
 if (typeof GM_addStyle != "undefined") {
     GM_addStyle(css);
@@ -30,3 +31,4 @@ if (typeof GM_addStyle != "undefined") {
         heads[0].appendChild(node);
     }
 }
+


### PR DESCRIPTION
Two small changes. Firstly it assumes everything with the class .editable should have the font monospace. The only quirk this produces is when you compose an HTML email, you will compose in monospace, but the UI will show your current font as Sans Serif. This is just a confused UI issue though - it sends without any style information added, so the receiver will just display using their default font, which seems to be the right thing to do.

The second change is I removed the colour override for quoted text, since gmail does threaded colouring now.

Now my pull request is about the length of the script :-)
